### PR TITLE
Update three.js CDN references

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,18 +8,18 @@
     </head>
     <body>
         <!-- Main three.js -->
-        <script src="https://threejs.org/build/three.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/build/three.min.js"></script>
 
         <!-- Orbital controls -->
         <script
             type="module"
-            src="https://threejs.org/examples/js/controls/OrbitControls.js"
+            src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/controls/OrbitControls.js"
         ></script>
 
         <!-- Loader -->
         <script
             type="module"
-            src="https://threejs.org/examples/jsm/loaders/FBXLoader.js"
+            src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/jsm/loaders/FBXLoader.js"
         ></script>
 
         <script type="module" src="./script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Import necessary loader
-import { FBXLoader } from "https://threejs.org/examples/jsm/loaders/FBXLoader.js";
+import { FBXLoader } from "https://cdn.jsdelivr.net/npm/three@0.132.2/examples/jsm/loaders/FBXLoader.js";
 
 // What the info box displays
 let infoBoxText = {


### PR DESCRIPTION
## Summary
- replace the defunct threejs.org CDN URLs with stable jsDelivr links so three.js and its helpers load again

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d99711a0fc8323adf48d4079c1b3e8