### PR TITLE
Fix three.js helper loading regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,21 +8,15 @@
     </head>
     <body>
         <!-- Main three.js -->
-        <script src="https://threejs.org/build/three.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/build/three.min.js"></script>
 
         <!-- Orbital controls -->
-        <script
-            type="module"
-            src="https://threejs.org/examples/js/controls/OrbitControls.js"
-        ></script>
+        <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/controls/OrbitControls.js"></script>
 
         <!-- Loader -->
-        <script
-            type="module"
-            src="https://threejs.org/examples/jsm/loaders/FBXLoader.js"
-        ></script>
+        <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/loaders/FBXLoader.js"></script>
 
-        <script type="module" src="./script.js"></script>
+        <script src="./script.js"></script>
         <h1 class="instruction">
             Click any part of the cell to get more details!
         </h1>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,3 @@
-// Import necessary loader
-import { FBXLoader } from "https://threejs.org/examples/jsm/loaders/FBXLoader.js";
-
 // What the info box displays
 let infoBoxText = {
     error: {
@@ -82,7 +79,7 @@ let loading = document.getElementById("loadingIndicator");
 
 
 // Loader
-const fbxLoader = new FBXLoader();
+const fbxLoader = new THREE.FBXLoader();
 
 // Assigns scene
 scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- switch OrbitControls and FBXLoader to the legacy global helper scripts so they attach to THREE
- drop the module import and instantiate FBXLoader from the global THREE namespace

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d99711a0fc8323adf48d4079c1b3e8