### PR TITLE
Add missing fflate dependency for FBXLoader

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/controls/OrbitControls.js"></script>
 
         <!-- Loader -->
+        <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/libs/fflate.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/loaders/FBXLoader.js"></script>
 
         <script src="./script.js" defer></script>


### PR DESCRIPTION
## Summary
- include the fflate library from the Three.js examples before loading FBXLoader to satisfy its dependency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e32d6f91288323b23fb4fa89fffb36